### PR TITLE
Feature/remove ignition math2 dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ find_package(catkin REQUIRED COMPONENTS
   kobuki_msgs
 )
 
-find_package(ignition-math2 REQUIRED)
-
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
@@ -145,7 +143,7 @@ catkin_package(
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
-  ${IGNITION-MATH2_INCLUDE_DIRS}
+  ${IGNITION-MATH_INCLUDE_DIRS}
 )
 
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")

--- a/package.xml
+++ b/package.xml
@@ -61,6 +61,7 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/package.xml
+++ b/package.xml
@@ -61,7 +61,6 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
-
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
#3 ROS kinetic, melodicでignition-math2は手動で入れる問題があるが、そもそもこのパッケージは最新のignition-math (Gazebo 9ではignition-math4)でも問題無くビルド・動作できています。

@nyxrobotics @MikhailBertrand @h-wata @Tacha-S 動作確認をお願いします。